### PR TITLE
fixed slashing url

### DIFF
--- a/src/main/java/com/kumuluz/ee/cors/filters/DynamicCorsFilter.java
+++ b/src/main/java/com/kumuluz/ee/cors/filters/DynamicCorsFilter.java
@@ -87,7 +87,7 @@ public class DynamicCorsFilter implements Filter {
             }
 
             if (path.endsWith("/")) {
-                path = path.substring(0, path.length() - 2);
+                path = path.substring(0, path.length() - 1);
             }
 
             CORSConfiguration configuration = getMaxMatchingUrlPatternConfig(path);


### PR DESCRIPTION
If url had '/' at the end it was too much cut off. example '/context/' became '/contex'.
The problem was when trying to access web app at root '/', when there was StringOutOfbounsException error. Fixed to remove only last slash.