### PR TITLE
Fixed incorrect reading of configuration keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Example CORS filter configuration (config.yaml):
 kumuluzee:
   cors-filter:
     servlet:
+      enabled: true
       allow-generic-http-requests: false
       allow-origin: "*"
 ```
@@ -195,6 +196,9 @@ CORS servlet filter should be used for Servlet applications which don't use @Web
 
 Remember to restart your web application or server after changing the CORS configuration!
 
+##### Disabling CORS Servlet filter
+
+To disable CORS servlet filter, simply set `kumuluzee.cors-filter.servlet.enabled`to `false`.
 
 ## Changelog
 

--- a/src/main/java/com/kumuluz/ee/cors/CorsExtension.java
+++ b/src/main/java/com/kumuluz/ee/cors/CorsExtension.java
@@ -63,13 +63,13 @@ public class CorsExtension implements Extension {
 
             ConfigurationUtil cfg = ConfigurationUtil.getInstance();
 
-            Optional<String> corsFilterOpt = cfg.get("kumuluzee.cors-filter.servlet");
+            boolean corsEnabled = cfg.getBoolean("kumuluzee.cors-filter.servlet.enabled").orElse(true);
 
             CorsConfig corsConfig = null;
 
             boolean isCrossOriginAnnotationsPresent = isCrossOriginAnnotationUsed();
 
-            if (corsFilterOpt.isPresent() && !isCrossOriginAnnotationsPresent) {
+            if (corsEnabled && !isCrossOriginAnnotationsPresent) {
 
                 log.info("CORS filter configuration detected.");
 


### PR DESCRIPTION
Added `enabled` flag to determine if extension should be initialized or not, instead of checking for root option (removed in kumuluzee 4.2.0)